### PR TITLE
Fixes for windows build

### DIFF
--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1020,13 +1020,20 @@ zlib-$(ZLIB_VER)/configure: zlib-$(ZLIB_VER).tar.gz
 	tar zxf $<
 	touch $@
 zlib-$(ZLIB_VER)/config.status: zlib-$(ZLIB_VER)/configure
+ifeq ($(OS), WINNT)
+	cd zlib-$(ZLIB_VER) && \
+	cp win32/Makefile.gcc Makefile
+else
 	cd zlib-$(ZLIB_VER) && \
 	./configure --prefix=$(abspath $(USR))
+endif
 	touch $@
 $(ZLIB_OBJ_TARGET): zlib-$(ZLIB_VER)/config.status
 	$(MAKE) -C zlib-$(ZLIB_VER) CC="$(CC)"
+ifneq ($(OS), WINNT)
 	$(MAKE) -C zlib-$(ZLIB_VER) check
-	$(MAKE) -C zlib-$(ZLIB_VER) install
+	PREFIX=$(USRLIB) $(MAKE) -C zlib-$(ZLIB_VER) install
+endif
 	$(INSTALL_NAME_CMD)libz.dylib $@
 	touch $@
 

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -1,4 +1,4 @@
-
+{
   global:
     asprintf;
     bitvector_any1;


### PR DESCRIPTION
deps/Makefile: use zlib win32 makefile
src/julia.expmap: syntax error, missing bracket
ui/repl-readline.c: reorder function declaration to resolve error from implicit declaration
