### PR TITLE
small fixes for windows build

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -123,11 +123,6 @@ function run_repl()
         end
         _jl_eval_user_input(ast, show_value!=0)
     end
-
-    if iserr
-        throw(lasterr)
-    end
-    println()
 end
 
 function parse_input_line(s::String)

--- a/deps/Makefile
+++ b/deps/Makefile
@@ -1046,7 +1046,7 @@ endif
 $(ZLIB_OBJ_TARGET): zlib-$(ZLIB_VER)/config.status
 	$(MAKE) -C zlib-$(ZLIB_VER) CC="$(CC)"
 ifeq ($(OS), WINNT)
-	cp zlib-${ZLIB_VER)/zlib1.dll $@
+	cp zlib-$(ZLIB_VER)/zlib1.dll $@
 else
 	$(MAKE) -C zlib-$(ZLIB_VER) check
 	PREFIX=$(USRLIB) $(MAKE) -C zlib-$(ZLIB_VER) install


### PR DESCRIPTION
deps/Makefile: fix syntax error that breaks clean build.
base/client.jl: iserr check at end of run_repl is no longer in main repo. causes error message on exit.
